### PR TITLE
Use https:// for rabbit_common

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {deps, [
     %%{rabbit_common, ".*", {git, "git://github.com/jbrisbin/rabbit_common.git", {tag, "rabbitmq-3.5.0"}}}
     %% use our fork till upstream fixes the mochijson2 issue
-    {rabbit_common, ".*", {git, "git://github.com/alertlogic/rabbit_common", {branch, master}}}
+    {rabbit_common, ".*", {git, "https://github.com/alertlogic/rabbit_common.git", {branch, master}}}
 ]}.
 
 {erl_opts, [


### PR DESCRIPTION
It seems that git:// protocol can be a little less reliable for deps pulling; https:// works best for public deps.